### PR TITLE
feat: Add custom CKEditor keyboard shortcuts

### DIFF
--- a/TESTING_GUIDE.md
+++ b/TESTING_GUIDE.md
@@ -1,0 +1,50 @@
+# Testing Guide for Custom CKEditor Shortcuts
+
+This guide outlines the manual steps to test the `Ctrl+[` (Show Shortcuts) and `Ctrl+S` (Custom Save) functionality added by the `customShortcuts` plugin.
+
+## Prerequisites
+
+1.  Ensure you have a web browser.
+2.  Serve the project files using a simple local web server. (e.g., using Python: `python -m http.server` or `python3 -m http.server` from the repository root, then navigate to `http://localhost:8000/demo.html`). Direct opening of `demo.html` via `file:///` protocol might cause issues with `customConfig` loading or AJAX requests if any were involved (though not in this specific plugin's current state).
+
+## Test Cases
+
+### Test Case 1: `Ctrl+S` - Custom Save Shortcut
+
+1.  **Open `demo.html` in your web browser.**
+2.  **Allow the CKEditor instance to load completely.** You should see the editor interface with some sample text.
+3.  **Focus the editor**: Click inside the editing area.
+4.  **Press `Ctrl+S`** (or `Cmd+S` on macOS).
+5.  **Expected Result**:
+    *   An alert box should appear with the message: "Demo: Ctrl+S detected and forceSaveDocument() called!".
+    *   The browser's default "Save Page As..." dialog should NOT appear.
+    *   A CKEditor notification should appear at the top-right of the editor (or as configured by the theme) with the message "Document saved!" and a success styling.
+    *   The browser's developer console should show the log: "Demo: forceSaveDocument() called!".
+
+### Test Case 2: `Ctrl+[` - Show Keyboard Shortcuts
+
+1.  **Open `demo.html` in your web browser.**
+2.  **Allow the CKEditor instance to load completely.**
+3.  **Focus the editor**: Click inside the editing area.
+4.  **Press `Ctrl+[`**.
+5.  **Expected Result**:
+    *   A CKEditor dialog window should appear with the title "Keyboard Shortcuts".
+    *   The dialog should contain a list of available keyboard shortcuts and their corresponding commands (e.g., "Ctrl+S: customSaveCmd", "Ctrl+[: showKeyboardShortcutsCmd", "Ctrl+B: bold", etc.).
+    *   The list should be reasonably formatted (e.g., as an unordered list).
+    *   The dialog should have an "OK" button to close it.
+    *   Verify that common shortcuts like `Ctrl+B` (bold), `Ctrl+I` (italic) are listed, along with our custom ones.
+
+### Test Case 3: Plugin Loading and No Console Errors
+
+1.  **Open `demo.html` in your web browser.**
+2.  **Open your browser's developer console.**
+3.  **Allow the CKEditor instance to load completely.**
+4.  **Expected Result**:
+    *   The console should display the message: "customShortcuts plugin initialized for editor: editor1".
+    *   There should be no JavaScript errors related to CKEditor or the `customShortcuts` plugin in the console.
+
+## Notes
+
+*   If `forceSaveDocument()` were a real function in a CMS, `Ctrl+S` would trigger the actual save mechanism. The alert and console log are for demo purposes.
+*   The list of shortcuts in the `Ctrl+[` dialog will depend on all plugins loaded and their registered keystrokes. The formatting helper in the plugin attempts to make this human-readable.
+```

--- a/config.js
+++ b/config.js
@@ -1,0 +1,30 @@
+CKEDITOR.editorConfig = function( config ) {
+    // Define changes to default configuration here. For example:
+    // config.language = 'fr';
+    // config.uiColor = '#AADC6E';
+
+    // Add the customShortcuts plugin
+    // If extraPlugins is already set, append to it. Otherwise, create it.
+    config.extraPlugins = (config.extraPlugins ? config.extraPlugins + ',' : '') + 'customShortcuts';
+
+    // It's also important to tell CKEditor where to find the plugin,
+    // if it's not in the default 'plugins' folder.
+    // Assuming 'customShortcuts' directory is at the same level as 'plugins' directory
+    // or at the root of the website where ckeditor.js is located.
+    // If 'customShortcuts' is in the root of your project (like in this repo),
+    // and your CKEditor 'plugins' folder is elsewhere, you might need this:
+    // CKEDITOR.plugins.addExternal('customShortcuts', '/path/to/customShortcuts/', 'plugin.js');
+    // For this example, we assume 'customShortcuts' is alongside 'plugins' or CKEditor can find it.
+    // If 'customShortcuts' is in the repo root (as it is here), and CKEditor is also in the root,
+    // or if the 'plugins' folder is in the root, this might be:
+    // CKEDITOR.plugins.addExternal('customShortcuts', 'customShortcuts/', 'plugin.js');
+    // However, often CKEditor is in its own directory like 'ckeditor/', 
+    // and 'config.js' is inside it. If 'customShortcuts' is outside that, like in the project root,
+    // the path would be relative from ckeditor.js to the customShortcuts folder.
+    // For example, if ckeditor.js is in 'assets/ckeditor/' and customShortcuts is in 'plugins/customShortcuts' (project root based)
+    // then path might be '../../plugins/customShortcuts/'.
+
+    // For the current repository structure, if ckeditor.js is in the root,
+    // and customShortcuts folder is also in the root, this tells CKEditor where to find it:
+    CKEDITOR.plugins.addExternal('customShortcuts', 'customShortcuts/', 'plugin.js');
+};

--- a/customShortcuts/plugin.js
+++ b/customShortcuts/plugin.js
@@ -1,0 +1,132 @@
+CKEDITOR.plugins.add('customShortcuts', {
+    init: function(editor) {
+        console.log('customShortcuts plugin initialized for editor:', editor.name);
+
+        // Define the command to open the dialog
+        editor.addCommand('showKeyboardShortcutsCmd', {
+            exec: function(editor) {
+                var keystrokes = editor.keystrokeHandler.keystrokes;
+                var configKeystrokes = editor.config.keystrokes || {};
+                var allKeystrokes = Object.assign({}, keystrokes, configKeystrokes);
+
+                var shortcutsListHtml = '<ul>';
+                var commandName;
+                var keystrokeValue;
+
+                // Helper to format keystroke numbers into human-readable strings
+                function formatKeystroke(keystroke) {
+                    var string = '';
+                    if (keystroke & CKEDITOR.CTRL) string += 'Ctrl+';
+                    if (keystroke & CKEDITOR.ALT) string += 'Alt+';
+                    if (keystroke & CKEDITOR.SHIFT) string += 'Shift+';
+                    
+                    var baseKey = keystroke & 0xFFF; // Mask out modifier keys
+                    var charCode = 0;
+                    
+                    // Attempt to map common keycodes to characters or names
+                    // This is a simplified mapping and might need expansion
+                    if (baseKey >= 48 && baseKey <= 90) { // 0-9, A-Z
+                        string += String.fromCharCode(baseKey);
+                    } else if (baseKey >= 112 && baseKey <= 123) { // F1-F12
+                        string += 'F' + (baseKey - 111);
+                    } else {
+                        // Special key codes (add more as needed)
+                        switch(baseKey) {
+                            case 8: string += 'Backspace'; break;
+                            case 9: string += 'Tab'; break;
+                            case 13: string += 'Enter'; break;
+                            case 27: string += 'Esc'; break;
+                            case 32: string += 'Space'; break;
+                            case 33: string += 'PageUp'; break;
+                            case 34: string += 'PageDown'; break;
+                            case 35: string += 'End'; break;
+                            case 36: string += 'Home'; break;
+                            case 37: string += 'Left Arrow'; break;
+                            case 38: string += 'Up Arrow'; break;
+                            case 39: string += 'Right Arrow'; break;
+                            case 40: string += 'Down Arrow'; break;
+                            case 46: string += 'Delete'; break;
+                            case 219: string += '['; break;
+                            case 221: string += ']'; break;
+                            // Add other common key codes if necessary
+                            default: string += 'Keycode ' + baseKey; break;
+                        }
+                    }
+                    return string;
+                }
+
+                for (keystrokeValue in allKeystrokes) {
+                    if (allKeystrokes.hasOwnProperty(keystrokeValue)) {
+                        commandName = allKeystrokes[keystrokeValue];
+                        if (commandName) { // Ensure commandName is not false or undefined
+                             shortcutsListHtml += '<li><strong>' + formatKeystroke(parseInt(keystrokeValue, 10)) + ':</strong> ' + commandName + '</li>';
+                        }
+                    }
+                }
+                shortcutsListHtml += '</ul>';
+
+                // Store this HTML to be accessible by the dialog definition
+                editor._customShortcutsHtml = shortcutsListHtml;
+                
+                editor.openDialog('showShortcutsDialog');
+            },
+            canUndo: false // Important for commands that don't modify content
+        });
+
+        // --- Custom Save Command ---
+        editor.addCommand('customSaveCmd', {
+            exec: function(editor) {
+                // Assume a global function forceSaveDocument() exists in the CMS
+                if (typeof forceSaveDocument === 'function') {
+                    forceSaveDocument();
+                    editor.showNotification('Document saved!', 'success');
+                } else {
+                    editor.showNotification('Save function (forceSaveDocument) not found.', 'warning');
+                    console.warn('customShortcuts: forceSaveDocument() function is not defined.');
+                }
+            },
+            canUndo: false, // This command does not affect the editor's undo stack
+            modes: { wysiwyg: 1, source: 1 } // Make it available in both modes
+        });
+        
+        // Define the dialog for showing shortcuts
+        CKEDITOR.dialog.add('showShortcutsDialog', function(editor) {
+            return {
+                title: 'Keyboard Shortcuts',
+                minWidth: 400,
+                minHeight: 300,
+                contents: [
+                    {
+                        id: 'tab-list',
+                        label: 'Shortcuts List',
+                        elements: [
+                            {
+                                type: 'html',
+                                id: 'shortcutsHtmlContent', // Add an ID for easier access
+                                html: '<div>Loading shortcuts...</div>' 
+                            }
+                        ]
+                    }
+                ],
+                buttons: [CKEDITOR.dialog.okButton],
+                onShow: function() {
+                    // Access the stored HTML and set it to the dialog's HTML element
+                    var dialog = this;
+                    if (editor._customShortcutsHtml) {
+                        dialog.getContentElement('tab-list', 'shortcutsHtmlContent').getElement().setHtml(editor._customShortcutsHtml);
+                    } else {
+                        dialog.getContentElement('tab-list', 'shortcutsHtmlContent').getElement().setHtml('<div>Could not load shortcuts.</div>');
+                    }
+                }
+            };
+        });
+
+        // Assign Ctrl+[ to the command
+        // 219 is the keycode for '['
+        editor.setKeystroke(CKEDITOR.CTRL + 219, 'showKeyboardShortcutsCmd');
+        
+        // Assign Ctrl+S to the custom save command
+        // 83 is the keycode for 'S'
+        editor.setKeystroke(CKEDITOR.CTRL + 83, 'customSaveCmd'); 
+    }
+});

--- a/demo.html
+++ b/demo.html
@@ -1,0 +1,45 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <meta charset="utf-8">
+    <title>CKEditor Custom Shortcuts Demo</title>
+    <script src="//cdn.ckeditor.com/4.22.1/standard/ckeditor.js"></script>
+</head>
+<body>
+    <h1>CKEditor Custom Shortcuts Demo</h1>
+    <p>Press <strong>Ctrl+S</strong> to simulate saving the document.</p>
+    <p>Press <strong>Ctrl+[</strong> to view available keyboard shortcuts (may take a moment to load and format).</p>
+
+    <textarea name="editor1" id="editor1" rows="10" cols="80">
+        This is some sample text.
+    </textarea>
+
+    <script>
+        // Dummy function for the Ctrl+S demo
+        function forceSaveDocument() {
+            console.log('Demo: forceSaveDocument() called!');
+            alert('Demo: Ctrl+S detected and forceSaveDocument() called!');
+        }
+
+        // Initialize CKEditor
+        CKEDITOR.replace('editor1', {
+            customConfig: 'config.js', // Load our config.js from the root
+            toolbar: [
+                { name: 'document', items: [ 'Source', '-', 'Save', 'NewPage', 'Preview', 'Print', '-', 'Templates' ] },
+                { name: 'clipboard', items: [ 'Cut', 'Copy', 'Paste', 'PasteText', 'PasteFromWord', '-', 'Undo', 'Redo' ] },
+                { name: 'editing', items: [ 'Find', 'Replace', '-', 'SelectAll', '-', 'Scayt' ] },
+                { name: 'basicstyles', items: [ 'Bold', 'Italic', 'Underline', 'Strike', 'Subscript', 'Superscript', '-', 'CopyFormatting', 'RemoveFormat' ] },
+                '/',
+                { name: 'paragraph', items: [ 'NumberedList', 'BulletedList', '-', 'Outdent', 'Indent', '-', 'Blockquote', 'CreateDiv', '-', 'JustifyLeft', 'JustifyCenter', 'JustifyRight', 'JustifyBlock', '-', 'BidiLtr', 'BidiRtl', 'Language' ] },
+                { name: 'links', items: [ 'Link', 'Unlink', 'Anchor' ] },
+                { name: 'insert', items: [ 'Image', 'Table', 'HorizontalRule', 'Smiley', 'SpecialChar', 'PageBreak', 'Iframe' ] },
+                '/',
+                { name: 'styles', items: [ 'Styles', 'Format', 'Font', 'FontSize' ] },
+                { name: 'colors', items: [ 'TextColor', 'BGColor' ] },
+                { name: 'tools', items: [ 'Maximize', 'ShowBlocks' ] }
+            ],
+            height: 300
+        });
+    </script>
+</body>
+</html>


### PR DESCRIPTION
Adds a new CKEditor plugin `customShortcuts` that introduces two new keyboard shortcuts:

1.  `Ctrl+[`: Displays a dialog listing all available keyboard shortcuts registered with the editor. This helps you discover and utilize existing editor functionalities more efficiently. The list is dynamically generated by inspecting `editor.keystrokeHandler.keystrokes` and `editor.config.keystrokes`.

2.  `Ctrl+S`: Triggers a custom save command (`customSaveCmd`). In a real CMS integration, this command would invoke the CMS's save mechanism. For demonstration purposes, it calls a placeholder JavaScript function `forceSaveDocument()` and displays a success notification.

The plugin is structured in `customShortcuts/plugin.js`. A `config.js` is provided to demonstrate how to load the plugin using `extraPlugins` and `CKEDITOR.plugins.addExternal`. A `demo.html` page is included to showcase the functionality, loading CKEditor from a CDN and using the local plugin and config. A `TESTING_GUIDE.md` provides manual steps to verify the new shortcuts.